### PR TITLE
fix: pinned dockerode version to 3.3.2

### DIFF
--- a/package.json
+++ b/package.json
@@ -19,6 +19,7 @@
     "@serverless/kubernetes-namespace": "^0.2.0",
     "bluebird": "^3.7.1",
     "chalk": "^2.4.2",
+    "dockerode": "3.3.2",
     "node-fetch": "^2.6.0"
   },
   "devDependencies": {


### PR DESCRIPTION
One of the latest commits in [dockerode](https://www.npmjs.com/package/dockerode) brought forth a breaking change. As seen in [this commit](https://github.com/apocas/dockerode/commit/65071fa0c8a2b1f0a1d9b684da695a538feaf570), line 306 was modified from:

```javascript
entries: file.src
```

to:

```javascript
entries: file.src.slice()
```

which means that `src` cannot be undefined, which is the case for `serverless-knative`.

To workaround this issue, we manually pinned the `dockerode` version to `3.3.2`.

Signed-off-by: Tomer Figenblat <tfigenbl@redhat.com>
